### PR TITLE
Fix allOf and examples

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,9 +2,9 @@
 members = [
   "hsr",
   "hsr-codegen",
+  "test",
   "examples/quickstart",
   "examples/petstore",
   "examples/bench",
-  "test"
-  # "examples/petstore-expanded",
+  "examples/petstore-expanded",
 ]

--- a/examples/bench/README.md
+++ b/examples/bench/README.md
@@ -1,5 +1,52 @@
-## Quickstart
+## Benchmark
 
 This benchmark features just endpoints, a one basic `GET` and a basic `POST`.
 
-TODO How to run?
+To run, you will need to install `wrk2`
+
+``` sh
+# start the server
+cargo run --release
+```
+Separate terminal:
+
+``` sh
+# get benchmark
+wrk -c10 -d10 -t4 -R 130000 http://localhost:8000/bench
+
+# post benchmark
+wrk -c10 -d10 -t4 -R 130000 -s POST.lua http://localhost:8000/bench
+```
+You may need to adjust `-R <rate>` until you max out your cpus.
+
+
+## Results
+
+
+Get:
+``` sh
+➜ wrk -c10 -d10 -t4 -R 130000 http://localhost:8000/bench
+Running 10s test @ http://localhost:8000/bench
+  4 threads and 10 connections
+  Thread Stats   Avg      Stdev     Max   +/- Stdev
+    Latency   294.43ms  233.42ms 809.47ms   58.61%
+    Req/Sec       -nan      -nan   0.00      0.00%
+  1196889 requests in 10.00s, 85.61MB read
+Requests/sec: 119694.82
+Transfer/sec:      8.56MB
+```
+
+Post:
+
+``` sh
+➜ wrk -c10 -d10 -t4 -R 130000 -s POST.lua http://localhost:8000/bench
+Running 10s test @ http://localhost:8000/bench
+  4 threads and 10 connections
+  Thread Stats   Avg      Stdev     Max   +/- Stdev
+    Latency   943.52ms  612.25ms   2.14s    57.49%
+    Req/Sec       -nan      -nan   0.00      0.00%
+  1024410 requests in 10.00s, 133.84MB read
+Requests/sec: 102446.34
+Transfer/sec:     13.38MB
+
+```

--- a/examples/bench/bench.yaml
+++ b/examples/bench/bench.yaml
@@ -6,15 +6,15 @@ servers:
   - url: http://localhost:8000
 
 paths:
-  /:
+  /bench:
     get:
-      operationId: basicGet
+      operationId: basic_get
       responses:
         '200':
           description: Simple get
 
     post:
-      operationId: basicPost
+      operationId: basic_post
       requestBody:
         required: true
         content:

--- a/examples/bench/src/main.rs
+++ b/examples/bench/src/main.rs
@@ -6,21 +6,13 @@ struct Api;
 
 #[hsr::async_trait::async_trait(?Send)]
 impl api::BenchmarkApi for Api {
-    type Error = hsr::ServerError;
 
-    fn new(_url: hsr::Url) -> Self {
-        Api
+    async fn basic_get(&self) -> api::BasicGet {
+        api::BasicGet::Ok
     }
 
-    async fn basic_get(&self) -> Result<hsr::Success, api::BasicGetError<Self::Error>> {
-        Ok(hsr::Success)
-    }
-
-    async fn basic_post(
-        &self,
-        payload: api::Payload,
-    ) -> Result<api::Payload, api::BasicPostError<Self::Error>> {
-        Ok(payload)
+    async fn basic_post(&self, payload: api::Payload) -> api::BasicPost {
+        api::BasicPost::Ok(payload)
     }
 }
 
@@ -28,5 +20,5 @@ impl api::BenchmarkApi for Api {
 async fn main() -> std::io::Result<()> {
     let uri: hsr::Url = "http://127.0.0.1:8000".parse().unwrap();
     println!("Serving at '{}'", uri);
-    api::server::serve::<Api>(hsr::Config::with_host(uri)).await
+    api::server::serve(Api, hsr::Config::with_host(uri)).await
 }

--- a/examples/petstore-expanded/Cargo.toml
+++ b/examples/petstore-expanded/Cargo.toml
@@ -15,4 +15,4 @@ rand = "0.7.0"
 env_logger = "0.6.2"
 
 [features]
-rustfmt = ["hsr-codegen/rustfmt"]
+pretty = ["hsr-codegen/pretty"]

--- a/examples/petstore/Cargo.toml
+++ b/examples/petstore/Cargo.toml
@@ -25,4 +25,4 @@ serde = "1.0.106"
 actix-rt = "1.1.0"
 
 [features]
-rustfmt = ["hsr-codegen/rustfmt"]
+pretty = ["hsr-codegen/pretty"]

--- a/examples/quickstart/Cargo.toml
+++ b/examples/quickstart/Cargo.toml
@@ -14,4 +14,4 @@ env_logger = "0.7.1"
 actix-rt = "1.1.0"
 
 [features]
-rustfmt = ["hsr-codegen/rustfmt"]
+pretty = ["hsr-codegen/pretty"]

--- a/examples/quickstart/src/main.rs
+++ b/examples/quickstart/src/main.rs
@@ -4,12 +4,6 @@ struct Api;
 
 #[hsr::async_trait::async_trait(?Send)]
 impl QuickstartApi for Api {
-    type Error = hsr::ServerError;
-
-    fn new(_url: hsr::Url) -> Self {
-        Api
-    }
-
     async fn greet(&self, name: String) -> Greet {
         Greet::Ok(Hello {
             name,
@@ -28,7 +22,7 @@ async fn main() {
     std::thread::spawn(move || {
         println!("Serving at '{}'", uri);
         let mut system = hsr::actix_rt::System::new("main");
-        let server = server::serve::<Api>(hsr::Config::with_host(uri));
+        let server = server::serve(Api, hsr::Config::with_host(uri));
         system.block_on(server).unwrap();
     });
 

--- a/hsr-codegen/Cargo.toml
+++ b/hsr-codegen/Cargo.toml
@@ -37,4 +37,4 @@ tempdir = "0.3.7"
 yansi = "0.5.0"
 
 [features]
-rustfmt = [ "rustfmt-nightly" ]
+pretty = [ "rustfmt-nightly" ]

--- a/hsr-codegen/src/lib.rs
+++ b/hsr-codegen/src/lib.rs
@@ -428,10 +428,6 @@ pub(crate) struct TypeMetadata {
 }
 
 impl TypeMetadata {
-    fn nullable(self, nullable: bool) -> Self {
-        Self { nullable, ..self }
-    }
-
     fn visibility(self, visibility: Visibility) -> Self {
         Self { visibility, ..self }
     }
@@ -474,7 +470,7 @@ fn doc_comment(msg: impl AsRef<str>) -> TokenStream {
 
 fn get_derive_tokens() -> TokenStream {
     quote! {
-        # [derive(Debug, Clone, PartialEq, PartialOrd, hsr::Serialize, hsr::Deserialize)]
+        # [derive(Debug, Clone, PartialEq, hsr::Serialize, hsr::Deserialize)]
     }
 }
 
@@ -708,19 +704,19 @@ pub fn generate_from_yaml_source(mut yaml: impl std::io::Read) -> Result<String>
         #rust_client
     };
     let code = code.to_string();
-    #[cfg(feature = "rustfmt")]
+    #[cfg(feature = "pretty")]
     {
         debug!("Prettify");
         prettify_code(code)
     }
-    #[cfg(not(feature = "rustfmt"))]
+    #[cfg(not(feature = "pretty"))]
     {
         Ok(code)
     }
 }
 
 /// Run the code through `rustfmt`.
-#[cfg(feature = "rustfmt")]
+#[cfg(feature = "pretty")]
 pub fn prettify_code(input: String) -> Result<String> {
     let mut buf = Vec::new();
     {

--- a/test/Cargo.toml
+++ b/test/Cargo.toml
@@ -12,6 +12,7 @@ hsr = { path = "../hsr" }
 serde = "1.0.106"
 env_logger = "0.7.1"
 actix-rt = "1.1.0"
+serde_json = "1.0.51"
 
 [features]
-rustfmt = ["hsr-codegen/rustfmt"]
+pretty = ["hsr-codegen/pretty"]

--- a/test/README.md
+++ b/test/README.md
@@ -1,9 +1,11 @@
-## Quickstart
+## Test
 
-This is a very bare-bones server/client, defined in the spec `quickstart.yaml`.
+This spec and the accompanying code attempt to check the various aspects of
+code generation and execution. Generally, if a bug is found, a regression
+test for it should be added here.
 
-Execute `cargo run` to launch a basic demo.
+## Run
 
-It will start a simple server in one thread, access it through a client, print the result and exit.
-
-Amazed, impressed? Then, take a look at the code!
+``` sh
+cargo run
+```

--- a/test/src/main.rs
+++ b/test/src/main.rs
@@ -73,7 +73,8 @@ fn combination() -> api::Combination {
         "height": 1.88,
         "feet_info": {
             "number_of_toes": 6,
-            "webbed": true
+            "webbed": true,
+            "the_rest": "blah blah blah blah"
         }
     });
     serde_json::from_value(blob).unwrap()

--- a/test/src/main.rs
+++ b/test/src/main.rs
@@ -67,6 +67,18 @@ fn nullable_struct() -> api::NullableStruct {
     })
 }
 
+fn combination() -> api::Combination {
+    let blob = serde_json::json!({
+        "myName": "Alex",
+        "height": 1.88,
+        "feet_info": {
+            "number_of_toes": 6,
+            "webbed": true
+        }
+    });
+    serde_json::from_value(blob).unwrap()
+}
+
 // TODO make this into a 'normal' rust test suite not just a big main function
 
 #[actix_rt::main]
@@ -87,6 +99,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let client = client::Client::new(uri2);
     println!("Testing endpoints");
+
+    let _ = combination();
 
     assert_eq!(client.get_status().await?, api::GetStatus::Ok);
 

--- a/test/test-spec.yaml
+++ b/test/test-spec.yaml
@@ -177,3 +177,28 @@ components:
 
     Anything:
       type: any
+
+    Combination:
+      allOf:
+        - $ref: '#/components/schemas/Hello'
+        - type: object
+          required:
+            - height
+          properties:
+            height:
+              type: number
+            favourite_colour:
+              type: string
+            feet_info:
+              required:
+                - number_of_toes
+                - webbed
+              properties:
+                number_of_toes:
+                  type: integer
+                eats_toenails:
+                  type: boolean
+                webbed:
+                  type: boolean
+                the_rest:
+                  $ref: '#/components/schemas/Anything'


### PR DESCRIPTION
Fixed handling of allOf.

This meant that `petstore-expanded` was in play again, so then I went through and fixed all the examples, and added some new benchmark numbers.